### PR TITLE
Memory form validation, copy tweaks, and mobile fixes

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1333,6 +1333,10 @@ footer {
 }
 
 @media (max-width: 600px) {
+  .hero {
+    padding: 48px 0 56px;
+  }
+
   .hero-inner {
     flex-direction: column;
     align-items: center;

--- a/assets/style.css
+++ b/assets/style.css
@@ -2,6 +2,8 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400&family=Albert+Sans:wght@400;500;600&display=swap');
 
+.nowrap { white-space: nowrap; }
+
 /* ===== Design Tokens ===== */
 :root {
   --orange: #B34D18;

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
       <div class="footer-quote">&ldquo;Be excellent to each other. Party on, dudes!&rdquo;</div>
       <div class="footer-quote-attr">&mdash; Bill &amp; Ted&rsquo;s Excellent Adventure (words Izzy lived by)</div>
       <div class="footer-divider"></div>
-      <p class="footer-copy">With love from the Penston family: George, Zoe, Gwendolyn &amp; Maeve</p>
+      <p class="footer-copy">With love from the Penston family: George, Zoe, <span class="nowrap">Gwendolyn &amp; Maeve</span></p>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
             <div class="hero-label" data-stagger="1">Remembering Izzy</div>
             <h1 data-stagger="2">Izzy Penston</h1>
             <div class="hero-dates" data-stagger="3">November 6, 2000 &ndash; March 25, 2026</div>
-            <p class="hero-intro" data-stagger="4">Known to many as Izzy, and to others as Isaac, they lived fully and authentically in every chapter of their life. A lifelong lover of learning, beloved friend, and community member, Izzy had a gift for bringing laughter and joy to everyone who knew them.</p>
+            <p class="hero-intro" data-stagger="4">Known to many as Izzy, and to others as Isaac, they lived fully and authentically in every chapter of their life. A lifelong lover of learning, beloved friend, and community member, Izzy had a gift for bringing laughter and joy to all who knew them.</p>
           </div>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -232,7 +232,7 @@
 
       <section class="section" id="photos">
         <div class="section-label" data-reveal aria-hidden="true">Photos</div>
-        <h2 data-reveal>Moments &amp; Memories</h2>
+        <h2 data-reveal>Moments &amp; Photos</h2>
 
         <div class="gallery-grid" id="gallery-grid"></div>
 
@@ -250,17 +250,17 @@
         <div id="memories-list"></div>
 
         <div id="memories-load-more-wrap" style="display:none">
-          <button class="load-more" id="memories-load-more">Load More Memories</button>
+          <button class="load-more" id="memories-load-more">Load More</button>
         </div>
 
         <div style="text-align: center; margin-top: 32px;" data-reveal>
-          <button class="btn-primary" id="share-memory-btn" type="button">Share Your Memory of Izzy</button>
+          <button class="btn-primary" id="share-memory-btn" type="button">Share a Memory of Izzy</button>
         </div>
       </section>
 
       <section class="section" id="donate">
         <div class="section-label" data-reveal aria-hidden="true">Izzy&rsquo;s Legacy</div>
-        <h2 data-reveal>Honor Izzy&rsquo;s Memory</h2>
+        <h2 data-reveal>Honor Izzy&rsquo;s Legacy</h2>
 
         <p style="color: var(--text-secondary); margin-bottom: 24px; margin-left: 0;" data-reveal>Please consider donating to the causes closest to Izzy&rsquo;s heart.</p>
 

--- a/index.html
+++ b/index.html
@@ -311,23 +311,23 @@
           <div class="form-row">
             <div class="form-group">
               <label for="memory-name">Your Name *</label>
-              <input type="text" id="memory-name" name="name" class="form-input" required>
+              <input type="text" id="memory-name" name="name" class="form-input" required maxlength="100">
             </div>
 
             <div class="form-group">
               <label for="memory-relation">Relationship to Izzy</label>
-              <input type="text" id="memory-relation" name="relation" class="form-input" placeholder="Friend, classmate&hellip;">
+              <input type="text" id="memory-relation" name="relation" class="form-input" placeholder="Friend, classmate&hellip;" maxlength="100">
             </div>
           </div>
 
           <div class="form-group">
             <label for="memory-email">Email * <span class="form-hint-inline">(private &mdash; not displayed)</span></label>
-            <input type="email" id="memory-email" name="email" class="form-input" required>
+            <input type="email" id="memory-email" name="email" class="form-input" required maxlength="254">
           </div>
 
           <div class="form-group">
             <label for="memory-text">Your Memory *</label>
-            <textarea id="memory-text" name="message" class="form-textarea" required placeholder="Share a favorite memory, story, or what Izzy meant to you&hellip;"></textarea>
+            <textarea id="memory-text" name="message" class="form-textarea" required maxlength="2000" placeholder="Share a favorite memory, story, or what Izzy meant to you&hellip;"></textarea>
           </div>
 
           <div class="form-group">

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
 
       <section class="section" id="memories">
         <div class="section-label" data-reveal aria-hidden="true">Memories</div>
-        <h2 data-reveal>Words for Izzy</h2>
+        <h2 data-reveal>Remembering Izzy</h2>
 
         <div id="memories-list"></div>
 

--- a/worker/memory-submit.js
+++ b/worker/memory-submit.js
@@ -74,7 +74,7 @@ async function sendNotification(env, { name, relation, message, email }) {
     },
     body: JSON.stringify({
       from: 'memories@izzypenston.com',
-      to: ['gpenston@me.com', 'zozomay@gmail.com'],
+      to: ['gpenston@gmail.com', 'zozomay@gmail.com'],
       subject,
       html
     })

--- a/worker/memory-submit.js
+++ b/worker/memory-submit.js
@@ -164,6 +164,11 @@ async function handleSubmit(request, env) {
     return json({ ok: false, error: 'Name, email, and message are required.' }, 400);
   }
 
+  // Enforce field length limits
+  if (name.length > 100 || (relation && relation.length > 100) || email.length > 254 || message.length > 2000) {
+    return json({ ok: false, error: 'One or more fields exceed the maximum length.' }, 400);
+  }
+
   // Commit photos first (in parallel) — failures are non-fatal
   const photoUrls = [];
   if (photoFiles.length > 0) {

--- a/worker/memory-submit.js
+++ b/worker/memory-submit.js
@@ -53,34 +53,6 @@ async function githubFetch(path, env, options = {}) {
 }
 
 // --- Helpers ---
-
-async function sendNotification(env, { name, relation, message, email }) {
-  if (!env.RESEND_API_KEY) return;
-  const subject = `New memory from ${name}`;
-  const relationLine = relation ? `<p><strong>Relation:</strong> ${relation}</p>` : '';
-  const html = `
-    <h2>New memory submitted on izzypenston.com</h2>
-    <p><strong>Name:</strong> ${name}</p>
-    ${relationLine}
-    <p><strong>Email:</strong> ${email}</p>
-    <blockquote style="border-left:3px solid #B34D18;margin:16px 0;padding:0 16px;color:#555;">${message.replace(/\n/g, '<br>')}</blockquote>
-    <p><a href="https://izzypenston.com/admin">Review in admin</a></p>
-  `.trim();
-  await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Authorization': `Bearer ${env.RESEND_API_KEY}`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({
-      from: 'memories@izzypenston.com',
-      to: ['gpenston@gmail.com', 'zozomay@gmail.com'],
-      subject,
-      html
-    })
-  });
-}
-
 // --- Helpers ---
 
 // Upload a photo to assets/submissions/ and return the raw GitHub URL
@@ -237,11 +209,6 @@ async function handleSubmit(request, env) {
     console.error('GitHub API error:', err);
     return json({ ok: false, error: 'Failed to submit. Please try again.' }, 500);
   }
-
-  // Fire-and-forget notification — don't block the response
-  sendNotification(env, { name, relation, message, email }).catch(err => {
-    console.error('Resend error:', err);
-  });
 
   return json({ ok: true });
 }

--- a/worker/memory-submit.js
+++ b/worker/memory-submit.js
@@ -74,7 +74,7 @@ async function commitPhoto(arrayBuffer, index, name, env) {
   const res = await githubFetch(`/contents/${path}`, env, {
     method: 'PUT',
     body: JSON.stringify({
-      message: `Add photo from ${name}`,
+      message: `Add photo from ${name.replace(/[^\w\s'-]/g, '').slice(0, 50)}`,
       content: base64
     })
   });
@@ -86,6 +86,27 @@ async function commitPhoto(arrayBuffer, index, name, env) {
   }
 
   return `https://raw.githubusercontent.com/${REPO_OWNER}/${REPO_NAME}/main/${path}`;
+}
+
+// --- Input validation ---
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_PHOTO_BYTES = 1024 * 1024; // 1 MB
+
+// JPEG: FF D8 FF, PNG: 89 50 4E 47, WebP: RIFF....WEBP
+function hasValidImageHeader(buf) {
+  const b = new Uint8Array(buf.slice(0, 12));
+  if (b[0] === 0xFF && b[1] === 0xD8 && b[2] === 0xFF) return true;
+  if (b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4E && b[3] === 0x47) return true;
+  if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+      b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50) return true;
+  return false;
+}
+
+function sanitizeString(str) {
+  if (typeof str !== 'string') return '';
+  // Strip control characters (keep newlines/tabs for message field)
+  return str.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '').trim();
 }
 
 // --- Spam detection ---
@@ -148,11 +169,19 @@ async function handleSubmit(request, env) {
         const validTypes = ['image/jpeg', 'image/png', 'image/webp'];
         if (validTypes.includes(file.type)) {
           const buf = await file.arrayBuffer();
+          if (buf.byteLength > MAX_PHOTO_BYTES) continue;
+          if (!hasValidImageHeader(buf)) continue;
           photoFiles.push({ arrayBuffer: buf, type: file.type });
         }
       }
     }
   }
+
+  // Sanitize all text inputs
+  name = sanitizeString(name);
+  email = sanitizeString(email);
+  relation = sanitizeString(relation);
+  message = sanitizeString(message);
 
   // Spam check — silently succeed so bots don't retry with different content
   if (isSpam({ name, relation, message, website })) {
@@ -162,6 +191,11 @@ async function handleSubmit(request, env) {
   // Validate required fields
   if (!name || !email || !message) {
     return json({ ok: false, error: 'Name, email, and message are required.' }, 400);
+  }
+
+  // Validate email format
+  if (!EMAIL_RE.test(email)) {
+    return json({ ok: false, error: 'Please provide a valid email address.' }, 400);
   }
 
   // Enforce field length limits


### PR DESCRIPTION
## Summary
- Remove Resend email notifications (redundant — GitHub Issues already notify repo owners)
- Add input validation and security hardening to memory submissions (email validation, field length limits, photo magic bytes check, sanitization)
- "Words for Izzy" → "Remembering Izzy"
- Reduce repetition of "memory/memories" across section headings
- Tighten hero spacing on mobile
- Fix orphan "them." in hero intro
- Keep "Gwendolyn & Maeve" together in footer on mobile

## After merging
Run `cd worker && wrangler deploy` to deploy the worker changes (validation + Resend removal). You can also remove the `RESEND_API_KEY` secret from the Cloudflare dashboard.

https://claude.ai/code/session_018fz2iRtV1NwoWAri87Ezav