### PR TITLE
Fix mobile hero spacing and footer line break

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -2,7 +2,8 @@
 
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400&family=Albert+Sans:wght@400;500;600&display=swap');
 
-.nowrap { white-space: nowrap; }
+.mobile-br { display: none; }
+@media (max-width: 600px) { .mobile-br { display: block; } }
 
 /* ===== Design Tokens ===== */
 :root {
@@ -1336,7 +1337,7 @@ footer {
 
 @media (max-width: 600px) {
   .hero {
-    padding: 48px 0 56px;
+    padding: 24px 0 56px;
   }
 
   .hero-inner {

--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
       <div class="footer-quote">&ldquo;Be excellent to each other. Party on, dudes!&rdquo;</div>
       <div class="footer-quote-attr">&mdash; Bill &amp; Ted&rsquo;s Excellent Adventure (words Izzy lived by)</div>
       <div class="footer-divider"></div>
-      <p class="footer-copy">With love from the Penston family: George, Zoe, <span class="nowrap">Gwendolyn &amp; Maeve</span></p>
+      <p class="footer-copy">With love from the Penston family:<br class="mobile-br"> George, Zoe, Gwendolyn &amp; Maeve</p>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- Reduce hero top padding further (48px → 24px) on mobile
- Fix footer "Penston family" line break — names now stay on one line on mobile

https://claude.ai/code/session_018fz2iRtV1NwoWAri87Ezav