### PR TITLE
Hero padding fix and gallery text tweaks

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -3,7 +3,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,700;1,9..144,400&family=Albert+Sans:wght@400;500;600&display=swap');
 
 .mobile-br { display: none; }
-@media (max-width: 600px) { .mobile-br { display: block; } }
+.mobile-only { display: none; }
+@media (max-width: 600px) { .mobile-br { display: block; } .mobile-only { display: inline; } .desktop-only { display: none; } }
 
 /* ===== Design Tokens ===== */
 :root {

--- a/assets/style.css
+++ b/assets/style.css
@@ -1337,7 +1337,7 @@ footer {
 
 @media (max-width: 600px) {
   .hero {
-    padding: 24px 0 56px;
+    padding: 48px 0 56px;
   }
 
   .hero-inner {

--- a/index.html
+++ b/index.html
@@ -237,10 +237,10 @@
         <div class="gallery-grid" id="gallery-grid"></div>
 
         <div id="gallery-load-more-wrap">
-          <button class="load-more" id="gallery-load-more">Load More Photos</button>
+          <button class="load-more" id="gallery-load-more">Load More</button>
         </div>
 
-        <p class="gallery-footer" data-reveal>Click any photo to view larger. Have a photo to share? <a href="#memories">Send it with your memory below.</a></p>
+        <p class="gallery-footer" data-reveal><span class="desktop-only">Click</span><span class="mobile-only">Tap</span> any photo to view larger.<br> Have a photo to share? <a href="#memories">Send it with your memory below.</a></p>
       </section>
 
       <section class="section" id="memories">


### PR DESCRIPTION
## Summary
- Revert hero mobile padding back to 48px (24px was too tight)
- Gallery: "Load More Photos" → "Load More"
- Gallery: "Click" → "Tap" on mobile
- Gallery footer: break line before "Have a photo to share?"

https://claude.ai/code/session_018fz2iRtV1NwoWAri87Ezav