### PR TITLE
Gallery load-more tile and text tweaks

### DIFF
--- a/assets/gallery.js
+++ b/assets/gallery.js
@@ -3,7 +3,7 @@
   var photos = [];
   var shown = 0;
   var grid = document.getElementById('gallery-grid');
-  var btnWrap = document.getElementById('gallery-load-more-wrap');
+  var loadMoreTile = null;
 
   function createItem(photo) {
     var div = document.createElement('div');
@@ -40,13 +40,30 @@
   }
 
   function renderBatch() {
+    // Remove existing load-more tile before adding new photos
+    if (loadMoreTile && loadMoreTile.parentNode) {
+      loadMoreTile.parentNode.removeChild(loadMoreTile);
+    }
+
     var end = Math.min(shown + BATCH_SIZE, photos.length);
     for (var i = shown; i < end; i++) {
       grid.appendChild(createItem(photos[i]));
     }
     shown = end;
-    if (shown >= photos.length && btnWrap) {
-      btnWrap.style.display = 'none';
+
+    // Add load-more tile if there are more photos
+    if (shown < photos.length) {
+      loadMoreTile = document.createElement('div');
+      loadMoreTile.className = 'gallery-item gallery-load-more-tile';
+      loadMoreTile.setAttribute('role', 'button');
+      loadMoreTile.setAttribute('tabindex', '0');
+      loadMoreTile.setAttribute('aria-label', 'Load more photos');
+      loadMoreTile.innerHTML = '<span class="load-more-label">Load More</span>';
+      loadMoreTile.addEventListener('click', function () { renderBatch(); });
+      loadMoreTile.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); renderBatch(); }
+      });
+      grid.appendChild(loadMoreTile);
     }
   }
 
@@ -59,23 +76,13 @@
         photos = data.sort(function (a, b) { return a.order - b.order; });
         if (photos.length === 0) {
           grid.innerHTML = '<p style="color:var(--text-tertiary);grid-column:1/-1;text-align:center;">Photos coming soon.</p>';
-          if (btnWrap) btnWrap.style.display = 'none';
           return;
         }
         renderBatch();
-        if (shown >= photos.length && btnWrap) {
-          btnWrap.style.display = 'none';
-        }
       })
       .catch(function () {
         grid.innerHTML = '<p style="color:var(--text-tertiary);grid-column:1/-1;text-align:center;">Photos coming soon.</p>';
-        if (btnWrap) btnWrap.style.display = 'none';
       });
-
-    var btn = document.getElementById('gallery-load-more');
-    if (btn) {
-      btn.addEventListener('click', function () { renderBatch(); });
-    }
   }
 
   if (document.readyState === 'loading') {

--- a/assets/style.css
+++ b/assets/style.css
@@ -646,6 +646,29 @@ img {
 .gallery-item:focus-within .gallery-caption-text,
 .gallery-item:focus .gallery-caption-text { opacity: 1; }
 
+.gallery-load-more-tile {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 1;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.gallery-load-more-tile:hover {
+  background: var(--border);
+}
+
+.load-more-label {
+  font-family: 'Fraunces', serif;
+  font-size: 16px;
+  color: var(--text-secondary);
+  letter-spacing: 0.02em;
+}
+
 .gallery-footer {
   font-size: 13px;
   color: var(--text-tertiary);

--- a/index.html
+++ b/index.html
@@ -236,9 +236,6 @@
 
         <div class="gallery-grid" id="gallery-grid"></div>
 
-        <div id="gallery-load-more-wrap">
-          <button class="load-more" id="gallery-load-more">Load More</button>
-        </div>
 
         <p class="gallery-footer" data-reveal><span class="desktop-only">Click</span><span class="mobile-only">Tap</span> any photo to view larger.<br> Have a photo to share? <a href="#memories">Send it with your memory below.</a></p>
       </section>


### PR DESCRIPTION
## Summary
- Revert hero mobile padding to 48px
- Gallery: "Load More Photos" → "Load More"  
- Gallery: "Click" → "Tap" on mobile
- Gallery footer line break before "Have a photo to share?"
- Move "Load More" into the gallery grid as a tile instead of a standalone button

https://claude.ai/code/session_018fz2iRtV1NwoWAri87Ezav