### PR TITLE
Use body font for gallery load-more tile

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -663,8 +663,9 @@ img {
 }
 
 .load-more-label {
-  font-family: 'Fraunces', serif;
-  font-size: 16px;
+  font-family: 'Albert Sans', sans-serif;
+  font-size: 14px;
+  font-weight: 500;
   color: var(--text-secondary);
   letter-spacing: 0.02em;
 }


### PR DESCRIPTION
## Summary
- Switch gallery "Load More" tile label from Fraunces (heading font) to Albert Sans (body font) to match other UI elements

https://claude.ai/code/session_018fz2iRtV1NwoWAri87Ezav